### PR TITLE
Moved navbar to default.html

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,1 +1,1 @@
-
+edgetx.org

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -33,7 +33,7 @@
     <!-- MAIN CONTENT -->
     <div id="main_content_wrap" class="outer">
       <section id="main_content" class="inner">
-        <div id="navbar" align="center">
+        <p class="navbar" align="center">
           <a href="https://edgetx.org/index"><img src="https://github.com/EdgeTX/edgetx.github.io/blob/master/images/home.png?raw=true" align="center" height="44" width="83"></a>
           <a href="https://edgetx.org/about"><img src="https://github.com/EdgeTX/edgetx.github.io/blob/master/images/about.png?raw=true" align="center" height="46" width="83"></a>
           <a href="https://edgetx.org/faq"><img src="https://github.com/EdgeTX/edgetx.github.io/blob/master/images/faq.png?raw=true" align="center" height="44" width="83"></a>
@@ -41,10 +41,8 @@
           <a href="https://edgetx.org/devinfo"><img src="https://github.com/EdgeTX/edgetx.github.io/blob/master/images/dev.png?raw=true" align="center" height="44" width="83"></a>
           <a href="https://github.com/EdgeTX/edgetx.github.io/wiki/EdgeTX-User-WIKI"><img src="https://github.com/EdgeTX/edgetx.github.io/blob/master/images/wiki.png?raw=true" align="center" height="44" width="83"></a>
           <a href="https://edgetx.org/partnershipprogram"><img src="https://github.com/EdgeTX/edgetx.github.io/blob/master/images/partners.png?raw=true" align="center" height="44" width="83"></a>
-          </p>
-          
-           <p>&nbsp;</p>
-        </div> 
+        </p> 
+        <p>&nbsp;</p>
         {{ content }}
       </section>
     </div>

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -11,7 +11,6 @@
   </head>
 
   <body>
-
     <!-- HEADER -->
     <div id="header_wrap" class="outer">
         <header class="inner">
@@ -34,6 +33,18 @@
     <!-- MAIN CONTENT -->
     <div id="main_content_wrap" class="outer">
       <section id="main_content" class="inner">
+        <div id="navbar" align="center">
+          <a href="https://edgetx.org/index"><img src="https://github.com/EdgeTX/edgetx.github.io/blob/master/images/home.png?raw=true" align="center" height="44" width="83"></a>
+          <a href="https://edgetx.org/about"><img src="https://github.com/EdgeTX/edgetx.github.io/blob/master/images/about.png?raw=true" align="center" height="46" width="83"></a>
+          <a href="https://edgetx.org/faq"><img src="https://github.com/EdgeTX/edgetx.github.io/blob/master/images/faq.png?raw=true" align="center" height="44" width="83"></a>
+          <a href="https://edgetx.org/getedgetx"><img src="https://github.com/EdgeTX/edgetx.github.io/blob/master/images/get.png?raw=true" align="center" height="46" width="83"></a>
+          <a href="https://edgetx.org/devinfo"><img src="https://github.com/EdgeTX/edgetx.github.io/blob/master/images/dev.png?raw=true" align="center" height="44" width="83"></a>
+          <a href="https://github.com/EdgeTX/edgetx.github.io/wiki/EdgeTX-User-WIKI"><img src="https://github.com/EdgeTX/edgetx.github.io/blob/master/images/wiki.png?raw=true" align="center" height="44" width="83"></a>
+          <a href="https://edgetx.org/partnershipprogram"><img src="https://github.com/EdgeTX/edgetx.github.io/blob/master/images/partners.png?raw=true" align="center" height="44" width="83"></a>
+          </p>
+          
+           <p>&nbsp;</p>
+        </div> 
         {{ content }}
       </section>
     </div>

--- a/docs/about.md
+++ b/docs/about.md
@@ -1,14 +1,3 @@
-<p align="center">
-<a href="https://edgetx.org/index"><img src="https://github.com/EdgeTX/edgetx.github.io/blob/master/images/home.png?raw=true" align="center" height="44" width="83"></a>
-<a href="https://edgetx.org/about"><img src="https://github.com/EdgeTX/edgetx.github.io/blob/master/images/about.png?raw=true" align="center" height="46" width="83"></a>
-<a href="https://edgetx.org/faq"><img src="https://github.com/EdgeTX/edgetx.github.io/blob/master/images/faq.png?raw=true" align="center" height="44" width="83"></a>
-<a href="https://edgetx.org/getedgetx"><img src="https://github.com/EdgeTX/edgetx.github.io/blob/master/images/get.png?raw=true" align="center" height="46" width="83"></a>
-<a href="https://edgetx.org/devinfo"><img src="https://github.com/EdgeTX/edgetx.github.io/blob/master/images/dev.png?raw=true" align="center" height="44" width="83"></a>
-<a href="https://github.com/EdgeTX/edgetx.github.io/wiki/EdgeTX-User-WIKI"><img src="https://github.com/EdgeTX/edgetx.github.io/blob/master/images/wiki.png?raw=true" align="center" height="44" width="83"></a>
-<a href="https://edgetx.org/partnershipprogram"><img src="https://github.com/EdgeTX/edgetx.github.io/blob/master/images/partners.png?raw=true" align="center" height="44" width="83"></a>
-</p>
- <p>&nbsp;</p> 
- 
 ## About EdgeTX
 
 

--- a/docs/bylaws.md
+++ b/docs/bylaws.md
@@ -1,14 +1,3 @@
-<p align="center">
-<a href="https://edgetx.org/index"><img src="https://github.com/EdgeTX/edgetx.github.io/blob/master/images/home.png?raw=true" align="center" height="44" width="83"></a>
-<a href="https://edgetx.org/about"><img src="https://github.com/EdgeTX/edgetx.github.io/blob/master/images/about.png?raw=true" align="center" height="46" width="83"></a>
-<a href="https://edgetx.org/faq"><img src="https://github.com/EdgeTX/edgetx.github.io/blob/master/images/faq.png?raw=true" align="center" height="44" width="83"></a>
-<a href="https://edgetx.org/getedgetx"><img src="https://github.com/EdgeTX/edgetx.github.io/blob/master/images/get.png?raw=true" align="center" height="46" width="83"></a>
-<a href="https://edgetx.org/devinfo"><img src="https://github.com/EdgeTX/edgetx.github.io/blob/master/images/dev.png?raw=true" align="center" height="44" width="83"></a>
-<a href="https://github.com/EdgeTX/edgetx.github.io/wiki/EdgeTX-User-WIKI"><img src="https://github.com/EdgeTX/edgetx.github.io/blob/master/images/wiki.png?raw=true" align="center" height="44" width="83"></a>
-<a href="https://edgetx.org/partnershipprogram"><img src="https://github.com/EdgeTX/edgetx.github.io/blob/master/images/partners.png?raw=true" align="center" height="44" width="83"></a>
-</p>
- <p>&nbsp;</p> 
-
 # EdgeTX Project By-Laws
 
 ### Name

--- a/docs/devinfo.md
+++ b/docs/devinfo.md
@@ -1,16 +1,3 @@
-
-<p align="center">
-<a href="https://edgetx.org/index"><img src="https://github.com/EdgeTX/edgetx.github.io/blob/master/images/home.png?raw=true" align="center" height="44" width="83"></a>
-<a href="https://edgetx.org/about"><img src="https://github.com/EdgeTX/edgetx.github.io/blob/master/images/about.png?raw=true" align="center" height="46" width="83"></a>
-<a href="https://edgetx.org/faq"><img src="https://github.com/EdgeTX/edgetx.github.io/blob/master/images/faq.png?raw=true" align="center" height="44" width="83"></a>
-<a href="https://edgetx.org/getedgetx"><img src="https://github.com/EdgeTX/edgetx.github.io/blob/master/images/get.png?raw=true" align="center" height="46" width="83"></a>
-<a href="https://edgetx.org/devinfo"><img src="https://github.com/EdgeTX/edgetx.github.io/blob/master/images/dev.png?raw=true" align="center" height="44" width="83"></a>
-<a href="https://github.com/EdgeTX/edgetx.github.io/wiki/EdgeTX-User-WIKI"><img src="https://github.com/EdgeTX/edgetx.github.io/blob/master/images/wiki.png?raw=true" align="center" height="44" width="83"></a>
-<a href="https://edgetx.org/partnershipprogram"><img src="https://github.com/EdgeTX/edgetx.github.io/blob/master/images/partners.png?raw=true" align="center" height="44" width="83"></a>
-</p>
- <p>&nbsp;</p> 
-<p></p> 
-
 ## Development Information
 
 <p align="center">

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,14 +1,3 @@
-<p align="center">
-<a href="https://edgetx.org/index"><img src="https://github.com/EdgeTX/edgetx.github.io/blob/master/images/home.png?raw=true" align="center" height="44" width="83"></a>
-<a href="https://edgetx.org/about"><img src="https://github.com/EdgeTX/edgetx.github.io/blob/master/images/about.png?raw=true" align="center" height="46" width="83"></a>
-<a href="https://edgetx.org/faq"><img src="https://github.com/EdgeTX/edgetx.github.io/blob/master/images/faq.png?raw=true" align="center" height="44" width="83"></a>
-<a href="https://edgetx.org/getedgetx"><img src="https://github.com/EdgeTX/edgetx.github.io/blob/master/images/get.png?raw=true" align="center" height="46" width="83"></a>
-<a href="https://edgetx.org/devinfo"><img src="https://github.com/EdgeTX/edgetx.github.io/blob/master/images/dev.png?raw=true" align="center" height="44" width="83"></a>
-<a href="https://github.com/EdgeTX/edgetx.github.io/wiki/EdgeTX-User-WIKI"><img src="https://github.com/EdgeTX/edgetx.github.io/blob/master/images/wiki.png?raw=true" align="center" height="44" width="83"></a>
-<a href="https://edgetx.org/partnershipprogram"><img src="https://github.com/EdgeTX/edgetx.github.io/blob/master/images/partners.png?raw=true" align="center" height="44" width="83"></a>
-</p>
- <p>&nbsp;</p> 
-
 ## Frequently Asked Questions
 
 **Will development for OpenTX stop?**

--- a/docs/getedgetx.md
+++ b/docs/getedgetx.md
@@ -1,14 +1,3 @@
-<p align="center">
-<a href="https://edgetx.org/index"><img src="https://github.com/EdgeTX/edgetx.github.io/blob/master/images/home.png?raw=true" align="center" height="44" width="83"></a>
-<a href="https://edgetx.org/about"><img src="https://github.com/EdgeTX/edgetx.github.io/blob/master/images/about.png?raw=true" align="center" height="46" width="83"></a>
-<a href="https://edgetx.org/faq"><img src="https://github.com/EdgeTX/edgetx.github.io/blob/master/images/faq.png?raw=true" align="center" height="44" width="83"></a>
-<a href="https://edgetx.org/getedgetx"><img src="https://github.com/EdgeTX/edgetx.github.io/blob/master/images/get.png?raw=true" align="center" height="46" width="83"></a>
-<a href="https://edgetx.org/devinfo"><img src="https://github.com/EdgeTX/edgetx.github.io/blob/master/images/dev.png?raw=true" align="center" height="44" width="83"></a>
-<a href="https://github.com/EdgeTX/edgetx.github.io/wiki/EdgeTX-User-WIKI"><img src="https://github.com/EdgeTX/edgetx.github.io/blob/master/images/wiki.png?raw=true" align="center" height="44" width="83"></a>
-<a href="https://edgetx.org/partnershipprogram"><img src="https://github.com/EdgeTX/edgetx.github.io/blob/master/images/partners.png?raw=true" align="center" height="44" width="83"></a>
-</p>
- <p>&nbsp;</p> 
-
 ## Get EdgeTX
 
 *To see the list of improvements as well as limitations of EdgeTX,  

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,16 +1,3 @@
-
-<p align="center">
-<a href="https://edgetx.org/index"><img src="https://github.com/EdgeTX/edgetx.github.io/blob/master/images/home.png?raw=true" align="center" height="44" width="83"></a>
-<a href="https://edgetx.org/about"><img src="https://github.com/EdgeTX/edgetx.github.io/blob/master/images/about.png?raw=true" align="center" height="46" width="83"></a>
-<a href="https://edgetx.org/faq"><img src="https://github.com/EdgeTX/edgetx.github.io/blob/master/images/faq.png?raw=true" align="center" height="44" width="83"></a>
-<a href="https://edgetx.org/getedgetx"><img src="https://github.com/EdgeTX/edgetx.github.io/blob/master/images/get.png?raw=true" align="center" height="46" width="83"></a>
-<a href="https://edgetx.org/devinfo"><img src="https://github.com/EdgeTX/edgetx.github.io/blob/master/images/dev.png?raw=true" align="center" height="44" width="83"></a>
-<a href="https://github.com/EdgeTX/edgetx.github.io/wiki/EdgeTX-User-WIKI"><img src="https://github.com/EdgeTX/edgetx.github.io/blob/master/images/wiki.png?raw=true" align="center" height="44" width="83"></a>
-<a href="https://edgetx.org/partnershipprogram"><img src="https://github.com/EdgeTX/edgetx.github.io/blob/master/images/partners.png?raw=true" align="center" height="44" width="83"></a>
-</p>
-
- <p>&nbsp;</p> 
- 
 ## Join our community!
 [<img src="https://discordapp.com/api/guilds/839849772864503828/widget.png?style=banner2" alt="Discord Banner 1"/>](https://discord.gg/wF9wUKnZ6H)  [<img src="https://github.com/EdgeTX/edgetx.github.io/blob/master/images/FBGroup.png?raw=true" height="76" width="288"/>](https://www.facebook.com/groups/edgetx) 
  


### PR DESCRIPTION
The contents of the navigation bar were duplicated across every content page, I've moved them into the template. Hopefully this should minimize parity issues. I was also considering transforming the image-based buttons in the navbar into actual HTML buttons, but I haven't talked with anyone about that and i'm unsure/not confident how they should be styled, so I refrained from that in this pull request.