### PR TITLE
add additional HW design rules

### DIFF
--- a/docs/Radio-hardware-specifications-for-EdgeTX.md
+++ b/docs/Radio-hardware-specifications-for-EdgeTX.md
@@ -33,6 +33,11 @@
 * For radios with an internal module, lines to put the module into flashing mode to perform pass-through flashing
 * Unused GPIO pins shall be connected with a 10k resistor either to GND or VCC. The initial hw revision of a radio shall have them tied to GND, further revision shall use one or multiple of those pins to mark different hw revision of the radio to allow auto detection of the radio version or variant.
 
+### hardware design guidlines
+* all high speed interfaces like Quad/Octo/Hexa SPI, SDRAM, USB and SDIO shall be length / time of flight equalised
+    * relative timing constrains, e.g. for different SDRAM wires, shall be respected
+* STM32H7 CPUs shall be used with Quad or Octo SPI flash that supports DDR and at least 100 MHz of DDR SPI clock speed
+
 ### Optional (color)
 * Display backlight control via PWM - connection to hw-PWM capable pin on the MCU
 * Gimbals with either analog, PWM (e.g. TLE4998P3), SPI ADC (e.g. ADS7952) or UART communication

--- a/docs/Radio-hardware-specifications-for-EdgeTX.md
+++ b/docs/Radio-hardware-specifications-for-EdgeTX.md
@@ -1,7 +1,15 @@
 # Hardware Requirements for EdgeTX
 
+## wording
+* SHALL is used to express mandatory requirements (provisions that have to be followed):
+  * the negative form is SHALL NOT.
+* SHOULD is used to express recommendations (provisions that an implementation is expected to follow unless there is a strong reason for not doing so and has to be cleard by the EdgeTX team):
+  * the negative form is SHOULD NOT.
+* MAY is used to express permissible actions (provisions that an implementation is able to follow or not follow):
+  * the negative form is NEED NOT (in English MAY NOT is ambiguous, so NEED NOT is used instead).
+
 ## Support of STM32F MCUs
-* As of EdgeTX v2.10, no new radios based on STM32F2 MCUs will be accepted.
+* No new radios based on STM32F2 MCUs will be accepted.
 * As of EdgeTX v3.0, no new radios based on STM32F MCUs will be accepted.
 
 ## Color screen radios
@@ -10,7 +18,7 @@
 * MCU: presently only STM32F429BI and STM32F439BI with 2 MB flash are supported. Running at 168 MHz.
   Support for STM32H7/H7R MCUs is planned from EdgeTX v2.11 onwards, whereas H750 and H7R will be the first supported H7 MCUs.
 * SDRAM with minimally 8MB
-* SD/microSD card slot or embedded SD NAND (e.g. XTX XTSD04G, minimally 512 MByte). Connectivity via SDIO mandatory
+* SD/microSD card slot or embedded SD NAND (e.g. XTX XTSD04G, minimally 512 MByte). SDIO shall be used to connect the storage device.
 * Color display with minimally 480x272 pixels. Presently supported resolutions 480x272, 480x320 and 320x480 pixels.
   With EdgeTX v3, 800x480 pixel support is planned.
 * Either touch-screen or keys for navigation, or both.
@@ -19,11 +27,11 @@
 * Display connectivity via RGB565, future support for MIPI-DSI is planned for EdgeTX v3.
 * Present display controllers supported: internal STM32F4, ST7796S, HX8357D, ILI9481, ILI9486, ILI9488, NT35310.
 * possibility to flash the firmware via USB-DFU (with or without dedicated DFU button)
-* constantly enabled energy source for the real-time-clock
+* the real-time-clock shall be connected to a constantly enabled energy source
 * possibility to power down the radio from main microcontroller
 * possibility to sample the voltage of the main battery
-* Neopixel RGB LEDs only on PWM capable pins with DMA support
-* Serial-Wire-Debug header. Either pads for 2x5 pin 0.05" header
+* Neopixel RGB LEDs shall be connected only on PWM capable pins with DMA support
+* Serial-Wire-Debug header shall be available on radios provided to the EdgeTX team. Either pads for 2x5 pin 0.05" header
 
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; <img src="https://c.a.segger.com/fileadmin/images/products/J-Link/Accessory/Adapters/J-Link_9-pin_Cortex-M_Adapter.png">
 
@@ -45,10 +53,10 @@
 * for connecting the Quad/Octp SPI flash and RAM the pins used on the evaluation boards shall be used
   * For H7R, STM32H7S78-DK
   * For H7, STM32H750B-DK
-* STM32H7R MCUs can be used with Hexa-SPI PSRAM, one possible type is the IC used on the evaluation board.
+* STM32H7R MCUs may be used with Hexa-SPI PSRAM, one possible type is the IC used on the evaluation board.
   
 ### Optional (color)
-* Display backlight control via PWM - connection to hw-PWM capable pin on the MCU
+* Display backlight shall be controllable via PWM - connection to hw-PWM capable pin on the MCU
 * Gimbals with either analog, PWM (e.g. TLE4998P3), SPI ADC (e.g. ADS7952) or UART communication
 * Switches as digital or analog inputs
 * haptic vibrator, via binary or PWM output
@@ -115,7 +123,7 @@
 * Explicit audio mute pin
 * in case of integrated charging circuitry/circuitries, feedback to main MCU about charging status of each charger
 * for external RF module bay support: either JR-micro or JR-nano bay
-* If trainer socket present: in/out connected to hw-PWM capable pins
+* If trainer socket present: in/out shalle be connected to hw-PWM capable pins
 * GPIO extenders with I2C or SPI bus connectivity can be used for digital I/O. In case GPIO extenders are used as inputs, the interrupt output of the GPIO extender shall be connected to an input interrupt capable pin of the MCU. The interrupt lines of multiple GPIO extenders may be logically connected to the same MCU input line.
 * SPI flash
 * I2C EEPROM
@@ -127,5 +135,6 @@
 ---
 
 ## General Considerations
-* When the radio is equipped with flight mode buttons (6POS / six position switch), they should be connected in a way that they can be used individually (as 'customizable switches' in EdgeTX). In order to save MCU IO pins, this could be done using a single analog input and resistor ladder, or an I2C expander. These switches need to have visual feedback LEDs that can be controlled by the MCU. To save MCU IO pins, this could also be done using an  I2C expander, or WS2812 (aka Neopixel) single serial line LEDs. 
-* the H7R and H5 CPUs support USB-C power delivery, the charging circuit can be designed with this is mind
+* When the radio is equipped with flight mode buttons (6POS / six position switch), they should be connected in a way that they can be used individually (as 'customizable switches' in EdgeTX). In order to save MCU IO pins, this may be done using a single analog input and resistor ladder, or an I2C expander. These switches shall have visual feedback LEDs that can be controlled by the MCU. To save MCU IO pins, this may also be done using an I2C expander, or WS2812 (aka Neopixel) single serial line LEDs. 
+* the H7R and H5 CPUs support USB-C power delivery, the charging circuit may be designed with this is mind
+          

--- a/docs/Radio-hardware-specifications-for-EdgeTX.md
+++ b/docs/Radio-hardware-specifications-for-EdgeTX.md
@@ -1,12 +1,17 @@
 # Hardware Requirements for EdgeTX
 
+## Support of STM32F MCUs
+* we will not accept new radios based no STM32F2 MCUs<
+* we will not accept new radios with STM32F4 MCUs from EdgeTX v2.12 or EdgeTX v3 onwards (whichever comes first)
+  * except radios that have been announced to the EdgeTX team before that release
+
 ## Color screen radios
 
 ### Mandatory hardware features (color)
 * MCU: presently only STM32F429BI and STM32F439BI with 2 MB flash are supported. Running at 168 MHz.
-  Support for STM32F7/H7 MCUs is planned from EdgeTX v3 onwards, whereas H750 will be the first supported H7 MCU.
+  Support for STM32F7/H7/H7R MCUs is planned from EdgeTX v3 or v2.11 onwards, whereas H750 and H7R will be the first supported H7 MCUs.
 * SDRAM with minimally 8MB
-* SD/microSD card slot or embedded SD NAND (e.g. XTX XTSD04G, minimally 512 MByte). Connectivity via SDIO preferred.
+* SD/microSD card slot or embedded SD NAND (e.g. XTX XTSD04G, minimally 512 MByte). Connectivity via SDIO mandatory
 * Color display with minimally 480x272 pixels. Presently supported resolutions 480x272, 480x320 and 320x480 pixels.
   With EdgeTX v3, 800x480 pixel support is planned.
 * Either touch-screen or keys for navigation, or both.
@@ -30,14 +35,19 @@
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; <img src="https://c.a.segger.com/fileadmin/images/products/J-Trace/jtrace-pinout.png">
 
 * USB-C device mode connection
+    * H7R radios must support Hi-Speed (480 MBit/s) USB
 * For radios with an internal module, lines to put the module into flashing mode to perform pass-through flashing
 * Unused GPIO pins shall be connected with a 10k resistor either to GND or VCC. The initial hw revision of a radio shall have them tied to GND, further revision shall use one or multiple of those pins to mark different hw revision of the radio to allow auto detection of the radio version or variant.
 
 ### hardware design guidlines
 * all high speed interfaces like Quad/Octo/Hexa SPI, SDRAM, USB and SDIO shall be length / time of flight equalised
-    * relative timing constrains, e.g. for different SDRAM wires, shall be respected
+  * relative timing constrains, e.g. for different SDRAM wires, shall be respected
 * STM32H7 CPUs shall be used with Quad or Octo SPI flash that supports DDR and at least 100 MHz of DDR SPI clock speed
-
+* for connecting the Quad/Octp SPI flash and RAM the pins used on the evaluation boards shall be used
+  * For H7R, STM32H7S78-DK
+  * For H7, STM32H750B-DK
+* STM32H7R MCUs can be used with Hexa-SPI PSRAM, one possible type is the IC used on the evaluation board.
+  
 ### Optional (color)
 * Display backlight control via PWM - connection to hw-PWM capable pin on the MCU
 * Gimbals with either analog, PWM (e.g. TLE4998P3), SPI ADC (e.g. ADS7952) or UART communication
@@ -56,6 +66,8 @@
 * I2C EEPROM
 * Bluetooth module via UART
 * IMU (e.g. LSM6DS33)
+* I2C port extender
+  * if port extenders are used for inputs, the interrupt pin has to be connected to an interrupt capable pin of the MCU
 * SpaceMouse module
 
 ---
@@ -63,9 +75,10 @@
 ## Black-and-white radios
 
 ### Mandatory hardware features (B/W)
-* MCU: STM32F2 and STM32F4 with minimally 512 kByte flash (for new radios only STM32F4 with minimally 1 MB flash)
-  <br/> STM32F2 running at 120 MHz, STM32F4 running at 168 MHz
+* MCU: STM32F4 with minimally 1 MB flash running at 168 MHz
+  * Support for STM32H562/563 will be available from EdgeTX v3 or v2.11
 * SD/microSD card slot or embedded SD NAND (e.g. XTX XTSD04G, minimally 512 MByte)
+  * Starting with STM32H5 all new radios must use SDIO to connect the storage
 * Monochrome display with either 128x64 pixels or 212x64 pixels.
 * possibility to flash the firmware via USB-DFU (with or without dedicated DFU button)
 * constantly enabled energy source for the real-time-clock
@@ -87,11 +100,17 @@
 * For radios with an internal module, lines to put the module into flashing mode to perform pass-through flashing
 * Unused GPIO pins shall be connected with a 10k resistor either to GND or VCC. The initial hw revision of a radio shall have them tied to GND, further revision shall use one or multiple of those pins to mark different hw revision of the radio to allow auto detection of the radio version or variant.
 
+### hardware design guidlines
+* all high speed interfaces like Quad/Octo/Hexa SPI, SDRAM, USB and SDIO shall be length / time of flight equalised
+* possible pin assignments can be found in the documentation of the evaluation board: NUCLEO-H563ZI
+ 
 ### Optional (B/W)
 * Display backlight control via PWM - connection to hw-PWM capable pin on the MCU
 * Gimbals with either analog, PWM (e.g. TLE4998P3), SPI ADC (e.g. ADS7952) or UART communication
 * Switches as digital or analog inputs
 * haptic vibrator, via binary or PWM output
+* support for additional key navigation input. Supported keys: Enter, Return, Page>, Page<, Up/Down, System, Model, Tele.
+* support for encoder/roller user input
 * Audio output via STM32 integrated DAC
 * Explicit audio volume control, e.g. via I2C, SPI or further DAC output
 * Explicit audio mute pin
@@ -103,3 +122,11 @@
 * I2C EEPROM
 * Bluetooth module via UART
 * IMU (e.g. LSM6DS33)
+* I2C port extender
+  * if port extenders are used for inputs, the interrupt pin has to be connected to an interrupt capable pin of the MCU
+
+---
+
+## General Considerations
+* When the radio is equipped with flight mode button (6-Pos), those should be connected in a way that they can be used individually. To save pins for the illumination, LEDs with Neopixel interface can be used
+* the H7R and H5 CPUs support USB-C power delivery, the charging circuit can be designed with this is mind

--- a/docs/Radio-hardware-specifications-for-EdgeTX.md
+++ b/docs/Radio-hardware-specifications-for-EdgeTX.md
@@ -1,15 +1,14 @@
 # Hardware Requirements for EdgeTX
 
 ## Support of STM32F MCUs
-* we will not accept new radios based no STM32F2 MCUs<
-* we will not accept new radios with STM32F4 MCUs from EdgeTX v2.12 or EdgeTX v3 onwards (whichever comes first)
-  * except radios that have been announced to the EdgeTX team before that release
+* As of EdgeTX v2.10, no new radios based on STM32F2 MCUs will be accepted.
+* As of EdgeTX v3.0, no new radios based on STM32F MCUs will be accepted.
 
 ## Color screen radios
 
 ### Mandatory hardware features (color)
 * MCU: presently only STM32F429BI and STM32F439BI with 2 MB flash are supported. Running at 168 MHz.
-  Support for STM32F7/H7/H7R MCUs is planned from EdgeTX v3 or v2.11 onwards, whereas H750 and H7R will be the first supported H7 MCUs.
+  Support for STM32H7/H7R MCUs is planned from EdgeTX v2.11 onwards, whereas H750 and H7R will be the first supported H7 MCUs.
 * SDRAM with minimally 8MB
 * SD/microSD card slot or embedded SD NAND (e.g. XTX XTSD04G, minimally 512 MByte). Connectivity via SDIO mandatory
 * Color display with minimally 480x272 pixels. Presently supported resolutions 480x272, 480x320 and 320x480 pixels.
@@ -66,8 +65,8 @@
 * I2C EEPROM
 * Bluetooth module via UART
 * IMU (e.g. LSM6DS33)
-* I2C port extender
-  * if port extenders are used for inputs, the interrupt pin has to be connected to an interrupt capable pin of the MCU
+* I2C port expander
+  * if port expanders are used for inputs, the interrupt output pin(s) of the port expander(s) shall be connected to an interrupt capable input pin of the MCU
 * SpaceMouse module
 
 ---
@@ -78,7 +77,7 @@
 * MCU: STM32F4 with minimally 1 MB flash running at 168 MHz
   * Support for STM32H562/563 will be available from EdgeTX v3 or v2.11
 * SD/microSD card slot or embedded SD NAND (e.g. XTX XTSD04G, minimally 512 MByte)
-  * Starting with STM32H5 all new radios must use SDIO to connect the storage
+  * Starting with STM32H5 all new radios shall use SDIO to connect the storage
 * Monochrome display with either 128x64 pixels or 212x64 pixels.
 * possibility to flash the firmware via USB-DFU (with or without dedicated DFU button)
 * constantly enabled energy source for the real-time-clock
@@ -109,7 +108,7 @@
 * Gimbals with either analog, PWM (e.g. TLE4998P3), SPI ADC (e.g. ADS7952) or UART communication
 * Switches as digital or analog inputs
 * haptic vibrator, via binary or PWM output
-* support for additional key navigation input. Supported keys: Enter, Return, Page>, Page<, Up/Down, System, Model, Tele.
+* support for additional key navigation input, via keys: Enter, Return, Page>, Page<, Up/Down, System, Model, Tele.
 * support for encoder/roller user input
 * Audio output via STM32 integrated DAC
 * Explicit audio volume control, e.g. via I2C, SPI or further DAC output
@@ -122,11 +121,11 @@
 * I2C EEPROM
 * Bluetooth module via UART
 * IMU (e.g. LSM6DS33)
-* I2C port extender
-  * if port extenders are used for inputs, the interrupt pin has to be connected to an interrupt capable pin of the MCU
+* I2C port expander
+  * if port expanders are used for inputs, the interrupt output pin(s) of the port expander(s) shall be connected to an interrupt capable input pin of the MCU
 
 ---
 
 ## General Considerations
-* When the radio is equipped with flight mode button (6-Pos), those should be connected in a way that they can be used individually. To save pins for the illumination, LEDs with Neopixel interface can be used
+*  When the radio is equipped with flight mode buttons (6POS / six position switch), they should be connected in a way that they can be used individually (as 'customizable switches' in EdgeTX). In order to save MCU IO pins, this could be done using a single analog input and resistor ladder, or an I2C expander. These switches need to have visual feedback LEDs that can be controlled by the MCU. To save MCU IO pins, this could also be done using an  I2C expander, or WS2812 (aka Neopixel) single serial line LEDs. 
 * the H7R and H5 CPUs support USB-C power delivery, the charging circuit can be designed with this is mind

--- a/docs/Radio-hardware-specifications-for-EdgeTX.md
+++ b/docs/Radio-hardware-specifications-for-EdgeTX.md
@@ -34,7 +34,7 @@
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; <img src="https://c.a.segger.com/fileadmin/images/products/J-Trace/jtrace-pinout.png">
 
 * USB-C device mode connection
-    * H7R radios must support Hi-Speed (480 MBit/s) USB
+    * H7R radios shall support Hi-Speed (480 MBit/s) USB
 * For radios with an internal module, lines to put the module into flashing mode to perform pass-through flashing
 * Unused GPIO pins shall be connected with a 10k resistor either to GND or VCC. The initial hw revision of a radio shall have them tied to GND, further revision shall use one or multiple of those pins to mark different hw revision of the radio to allow auto detection of the radio version or variant.
 
@@ -127,5 +127,5 @@
 ---
 
 ## General Considerations
-*  When the radio is equipped with flight mode buttons (6POS / six position switch), they should be connected in a way that they can be used individually (as 'customizable switches' in EdgeTX). In order to save MCU IO pins, this could be done using a single analog input and resistor ladder, or an I2C expander. These switches need to have visual feedback LEDs that can be controlled by the MCU. To save MCU IO pins, this could also be done using an  I2C expander, or WS2812 (aka Neopixel) single serial line LEDs. 
+* When the radio is equipped with flight mode buttons (6POS / six position switch), they should be connected in a way that they can be used individually (as 'customizable switches' in EdgeTX). In order to save MCU IO pins, this could be done using a single analog input and resistor ladder, or an I2C expander. These switches need to have visual feedback LEDs that can be controlled by the MCU. To save MCU IO pins, this could also be done using an  I2C expander, or WS2812 (aka Neopixel) single serial line LEDs. 
 * the H7R and H5 CPUs support USB-C power delivery, the charging circuit can be designed with this is mind

--- a/docs/Radio-hardware-specifications-for-EdgeTX.md
+++ b/docs/Radio-hardware-specifications-for-EdgeTX.md
@@ -74,7 +74,7 @@
 ## Black-and-white radios
 
 ### Mandatory hardware features (B/W)
-* MCU: STM32F4 with minimally 1 MB flash running at 168 MHz
+* MCU: As of EdgeTX 2.10, STM32F4 with minimally 1 MB flash running at 168 MHz. From EdgeTX v2.11 onwards, STM32H562/563 will also be supported. New STM32F based designs will not be accepted as of EdgeTX v3.0.
   * Support for STM32H562/563 will be available from EdgeTX v3 or v2.11
 * SD/microSD card slot or embedded SD NAND (e.g. XTX XTSD04G, minimally 512 MByte)
   * Starting with STM32H5 all new radios shall use SDIO to connect the storage


### PR DESCRIPTION
H7 XiP requires fast flash memory
high speed interfaces need time of flight equalised traces

This PR adds coresponding requirements